### PR TITLE
Add extension to dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -73,7 +73,8 @@
 				"ms-toolsai.vscode-jupyter-slideshow",
 				"ms-toolsai.datawrangler",
 				"ms-python.vscode-python-envs",
-				"yy0931.mplstyle"
+				"yy0931.mplstyle",
+				"vincent-templier.vscode-netron"
 			]
 		}
 	},


### PR DESCRIPTION
Include the `vincent-templier.vscode-netron` extension in the development container configuration.